### PR TITLE
Add getSummaryData method to return thumbnail and title for summary s…

### DIFF
--- a/src/Block/FileBlock.php
+++ b/src/Block/FileBlock.php
@@ -40,6 +40,21 @@ class FileBlock extends BaseElement
     }
 
     /**
+     * Return file title and thumbnail for summary section of ElementEditor
+     *
+     * @return array
+     */
+    public function getBlockSchema()
+    {
+        $blockSchema = parent::getBlockSchema();
+        if ($this->File() && $this->File()->exists() && $this->File()->getIsImage()) {
+            $blockSchema["fileURL"] = $this->File()->CMSThumbnail()->getURL();
+            $blockSchema["fileTitle"] = $this->File()->getTitle();
+        }
+        return $blockSchema;
+    }
+
+    /**
      * Return a thumbnail of the file, if it's an image. Used in GridField preview summaries.
      *
      * @return DBHTMLText

--- a/src/Block/FileBlock.php
+++ b/src/Block/FileBlock.php
@@ -44,12 +44,12 @@ class FileBlock extends BaseElement
      *
      * @return array
      */
-    public function getBlockSchema()
+    protected function provideBlockSchema()
     {
-        $blockSchema = parent::getBlockSchema();
+        $blockSchema = parent::provideBlockSchema();
         if ($this->File() && $this->File()->exists() && $this->File()->getIsImage()) {
-            $blockSchema["fileURL"] = $this->File()->CMSThumbnail()->getURL();
-            $blockSchema["fileTitle"] = $this->File()->getTitle();
+            $blockSchema['fileURL'] = $this->File()->CMSThumbnail()->getURL();
+            $blockSchema['fileTitle'] = $this->File()->getTitle();
         }
         return $blockSchema;
     }

--- a/tests/Block/FileBlockTest.php
+++ b/tests/Block/FileBlockTest.php
@@ -42,6 +42,7 @@ class FileBlockTest extends SapphireTest
 
     public function testGetSummaryReturnsThumbnailAndFileTitle()
     {
+        /** @var FileBlock $block */
         $block = $this->objFromFixture(FileBlock::class, 'with_image');
 
         $summary = $block->getSummary();
@@ -52,6 +53,7 @@ class FileBlockTest extends SapphireTest
 
     public function testGetSummaryReturnsFileTitleWhenLinkedToFile()
     {
+        /** @var FileBlock $block */
         $block = $this->objFromFixture(FileBlock::class, 'with_file');
 
         $summary = $block->getSummary();
@@ -59,5 +61,16 @@ class FileBlockTest extends SapphireTest
         $this->assertContains('elemental-preview__thumbnail-image', $summary);
         $this->assertContains('elemental-preview__thumbnail-image--placeholder', $summary);
         $this->assertContains('Some file', $summary);
+    }
+
+    public function testImageIsAddedToSchemaData()
+    {
+        /** @var FileBlock $block */
+        $block = $this->objFromFixture(FileBlock::class, 'with_image');
+
+        $schemaData = $block->getBlockSchema();
+
+        $this->assertNotEmpty($schemaData['fileURL'], 'File URL is added to schema');
+        $this->assertNotEmpty($schemaData['fileTitle'], 'File title is added to schema');
     }
 }


### PR DESCRIPTION
…ection of ElementEditor

Required for https://github.com/dnadesign/silverstripe-elemental/pull/284 to allow the required data - content summary - to be pulled in via GraphQL

Requires https://github.com/dnadesign/silverstripe-elemental/pull/313