### PR TITLE
Revert translation

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,8 +1,8 @@
 en:
   SilverStripe\ElementalFileBlock\Block\FileBlock:
     BlockType: File
-    PLURALNAME: files
+    PLURALNAME: 'file blocks'
     PLURALS:
-      one: 'A file'
-      other: '{count} files'
-    SINGULARNAME: file
+      one: 'A file block'
+      other: '{count} file blocks'
+    SINGULARNAME: 'file block'


### PR DESCRIPTION
Revert a translation update that cow inadvertently made last release

It's supposed to be 'file block(s)', not 'file(s)' https://github.com/silverstripe/silverstripe-elemental-fileblock/pull/18

Tag 2.1.2 when this is merged and remember to merge-up