### PR TITLE
MNT Require recipe-testing for behat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "silverstripe/assets": "^1.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3.0"
+        "silverstripe/recipe-testing": "^2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/492

Unit test is failing because elemental 4.8.0 which has php8 support hasn't been released. instead it installs a rather ancient elemental 4.3.2 which has no php constraint

Regardless this is a good PR to merge now that the module has behat tests