### PR TITLE
ENH Add tests for asset modal breadcrumbs

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -5,6 +5,7 @@ default:
         - "%paths.modules.elemental-fileblock%/tests/behat/features"
       contexts:
         - SilverStripe\Admin\Tests\Behat\Context\AdminContext
+        - SilverStripe\AssetAdmin\Tests\Behat\Context\FeatureContext
         - SilverStripe\BehatExtension\Context\BasicContext
         - SilverStripe\BehatExtension\Context\EmailContext
         - SilverStripe\BehatExtension\Context\LoginContext

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "silverstripe/vendor-plugin": "^1.0",
         "dnadesign/silverstripe-elemental": "^4.8",
         "silverstripe/cms": "^4.3",
-        "silverstripe/assets": "^1.3"
+        "silverstripe/assets": "^1.3",
+        "silverstripe/asset-admin": "^1.0"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^2"

--- a/tests/behat/features/elemental-fileblock.feature
+++ b/tests/behat/features/elemental-fileblock.feature
@@ -8,12 +8,11 @@ Feature: Use elemental fileblock
     And a "page" "My page"
     And a "folder" "assets/Uploads"
     And a "file" "assets/Uploads/test1.pdf"
+    And I am logged in with "EDITOR" permissions
+    And I go to "/admin/pages"
+    And I click on "My page" in the tree
 
   Scenario: Operate elemental fileblocks
-    Given I am logged in with "EDITOR" permissions
-    When I go to "/admin/pages"
-    And I follow "My page"
-
     # Add file block
     And I press the "Add block" button
     And I wait for 1 seconds
@@ -36,3 +35,35 @@ Feature: Use elemental fileblock
     # Assert that it saved
     And I click on the ".element-editor-header__title" element
     Then I should see a ".uploadfield-item--document" element
+
+  Scenario: I can use modal breadcrumbs to navigate up levels
+    # Add file block
+    When I press the "Add block" button
+      And I wait for 1 seconds
+      And I click on the ".font-icon-block-file" element
+      And I wait for 5 seconds
+      And I press the "Save" button
+
+      # Open inline editing and select file from gallery
+      And I click on the ".element-editor-header__expand" element
+      And I wait for 5 seconds
+      And I press the "Choose existing" button
+      And I wait for 1 seconds
+
+      # Test breadcrumbs
+      And I press the "Back" HTML field button
+      And I select the file named "folder1" in the gallery
+      And I select the file named "folder1-1" in the gallery
+    Then I should see the breadcrumb link "Files"
+      And I should see the breadcrumb link "folder1"
+      And I should not see the breadcrumb link "folder1-1"
+    When I click on the breadcrumb link "folder1"
+      Then I should see the file named "folder1-1" in the gallery
+      And I should not see the breadcrumb link "folder1"
+      # Validate that we haven't navigated away from the pages admin
+      And I can see the preview panel
+    When I click on the breadcrumb link "Files"
+    Then I should see the file named "folder1" in the gallery
+      And I should not see the breadcrumb link "Files"
+      # Validate that we haven't navigated away from the pages admin
+      And I can see the preview panel


### PR DESCRIPTION
Also require asset-admin as a dependency. This is necessary to use the behat test context - but it also should already have been a dependency since the `UploadField` is used.

## Parent issue
silverstripe/silverstripe-asset-admin#1007

## Dependencies
- Requires silverstripe/silverstripe-admin#1299