### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
+        "silverstripe/framework": "^4.10",
         "silverstripe/vendor-plugin": "^1.0",
-        "dnadesign/silverstripe-elemental": "4.11.x-dev",
-        "silverstripe/cms": "4.13.x-dev",
-        "silverstripe/assets": "1.13.x-dev"
+        "dnadesign/silverstripe-elemental": "^4.8",
+        "silverstripe/cms": "^4.3",
+        "silverstripe/assets": "^1.3"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^2"


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33